### PR TITLE
LiDAR 3D model and name

### DIFF
--- a/urdf/marta.xacro
+++ b/urdf/marta.xacro
@@ -402,10 +402,10 @@
   </xacro:wheel_assembly>
 
   <!-- Sensors -->
-  <xacro:include filename="$(find rover_config)/urdf/lidar.xacro"/>
+  <xacro:include filename="$(find rover_config)/urdf/vlp_16.xacro"/>
 
   <xacro:lidar parent_link="base_link">
-    <origin xyz="0 0  ${chassis_z}"/>
+    <origin xyz="0 0  ${chassis_z + 0.006}"/>
   </xacro:lidar>
 
 </robot>

--- a/urdf/vlp_16.gazebo
+++ b/urdf/vlp_16.gazebo
@@ -43,5 +43,10 @@
         <output_type>sensor_msgs/PointCloud2</output_type>
       </plugin>
     </sensor>
+
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+    <material>Gazebo/Gray</material>
+
   </gazebo>
 </robot>

--- a/urdf/vlp_16.xacro
+++ b/urdf/vlp_16.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:macro name="lidar" params="parent_link *origin">
-    <xacro:include filename="$(find rover_config)/urdf/lidar.gazebo" />
+    <xacro:include filename="$(find rover_config)/urdf/vlp_16.gazebo" />
     
     <joint name="joint_lidar" type="fixed">
       <parent link="${parent_link}"/>
@@ -9,13 +9,22 @@
       <xacro:insert_block name="origin" />
     </joint>
 
+    <!-- Model of Velodyne VLP-16 LiDAR -->
     <link name="link_lidar">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
-          <box size="0.1 0.1 0.1"/>
+          <cylinder length="0.0717" radius="0.05165"/>
+        </geometry>
+      </visual>
+
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder length="0.0717" radius="0.05165"/>
         </geometry>
       </visual>
     </link>
+
   </xacro:macro>
 </robot>


### PR DESCRIPTION
renamed lidar to specific velodyne model (vlp-16), changed 3D model to be cylindrical instead of a box.