### PR TITLE
Bring axes in line with lab convention

### DIFF
--- a/urdf/marta.xacro
+++ b/urdf/marta.xacro
@@ -14,7 +14,6 @@
   <xacro:property name="use_ptu"      value="$(arg use_ptu)" /> 
   <xacro:property name="use_loc_cam"  value="$(arg use_loc_cam)" /> 
 
-
   <!-- PHYSICS -->
   <xacro:property name="damping" value="2" />
   <xacro:property name="friction" value="0.1" />
@@ -70,7 +69,6 @@
   <xacro:property name="str_z" value="0.0435" />
   <xacro:property name="str_x_link_diff" value="0.017" />
 
-
   <!-- STEERING JOINT -->
   <!-- <xacro:property name="str_mass" value="0.025" /> -->
   <xacro:property name="str_mass" value="0.25" />
@@ -78,7 +76,6 @@
   <xacro:property name="str_pos_long_x" value="0.045" />
   <xacro:property name="str_pos_y" value="0.031" />
   <xacro:property name="str_pos_z" value="0.0305" />
-
 
   <!-- WHEEL -->
   <!-- <xacro:property name="wheel_mass" value="0.23" /> -->
@@ -142,8 +139,6 @@
     <child link="base_link_inertia"/>
   </joint>
 
-
-
   <!-- BOGIE DEFINITION -->
   <xacro:macro name="bogie" params="position bogie_mass bogie_r bogie_l dep_pos_z dep_rot_y *origin_bogie">
     <xacro:property name="bogie_link" value="link_bogie_${position}" />
@@ -167,6 +162,7 @@
               ixz="0"
               iyz="0"/>
       </inertial>
+
       <!-- BAR -->
       <collision>
         <origin xyz="0 0 0" rpy="0 ${pi / 2} 0"/>
@@ -239,6 +235,7 @@
               ixz="0"
               iyz="0"/>
       </inertial>
+
       <!-- STEERING MOTOR -->
       <collision>
         <origin xyz="${str_pos_x} ${str_pos_y-str_y/2} ${str_pos_z * side_sign}" rpy="0 0 0"/>
@@ -253,7 +250,6 @@
         </geometry>
       </visual>
     </link>
-
 
     <!-- STEERING JOINT -->
     <joint name="joint_STR_${position}" type="revolute">
@@ -392,7 +388,6 @@
     <origin xyz="-${str_pos_long_x} ${str_pos_y} ${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
 
-
   <!-- RIGHT BOGIE  -->
   <xacro:property name="side_bogie_right_name" value="RFB" />
 
@@ -426,7 +421,6 @@
     <origin xyz="${rear_dep_pos_x} ${rear_dep_pos_y} -${rear_dep_pos_z}" rpy="0 ${- pi / 2} 0"/>
     <origin xyz="-${str_pos_short_x} ${str_pos_y} -${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
-
 
   <!-- Sensors -->
   <!-- PTU w/ Navigation Cam-->
@@ -466,7 +460,6 @@
       <origin xyz="0.09 0  0"/>
     </xacro:imu>
   </xacro:if>
-
 
   <!-- GNSS -->
   <xacro:if value="${use_gnss}"> 

--- a/urdf/marta.xacro
+++ b/urdf/marta.xacro
@@ -145,7 +145,7 @@
 
 
   <!-- BOGIE DEFINITION -->
-  <xacro:macro name="bogie" params="position bogie_mass bogie_r bogie_l dep_pos_z dep_rot_y *origin_bogie *geometry">
+  <xacro:macro name="bogie" params="position bogie_mass bogie_r bogie_l dep_pos_z dep_rot_y *origin_bogie">
     <xacro:property name="bogie_link" value="link_bogie_${position}" />
 
     <joint name="joint_bogie_${position}" type="revolute">
@@ -171,14 +171,14 @@
       <collision>
         <origin xyz="0 0 0" rpy="0 ${pi / 2} 0"/>
         <geometry>
-          <xacro:insert_block name="geometry" />
+          <cylinder length="${bogie_l}" radius="${bogie_r}"/>
         </geometry>
       </collision>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 ${pi / 2} 0"/>
         <geometry>
-          <xacro:insert_block name="geometry" />
+          <cylinder length="${bogie_l}" radius="${bogie_r}"/>
         </geometry>
       </visual>
 
@@ -215,15 +215,15 @@
   </xacro:macro>
 
   <!-- Definition for a wheel assembly -->
-  <!-- Driving direction is used to invert the direction of the deployment and driving joint -->
-  <xacro:macro name="wheel_assembly" params="position bogie_name driving_direction str_pos_x *origin_DEP *origin_STR">
+  <xacro:macro name="wheel_assembly" params="position bogie_name str_pos_x side_sign *origin_DEP *origin_STR">
+
     <!-- DEPLOYMENT JOINT -->
     <joint name="joint_DEP_${position}" type="revolute">
       <parent link="link_bogie_${bogie_name}"/>
       <child link="link_DEP_${position}"/>
       <limit effort="${limit_steer_effort}" lower="${limit_steer_lower}" upper="${limit_steer_upper}" velocity="${limit_steer_velocity}"/>
       <xacro:insert_block name="origin_DEP" />
-      <axis xyz="0 0 ${driving_direction}"/>
+      <axis xyz="0 0 1"/>
       <dynamics damping="${damping}" friction="${friction}"/>
     </joint>
 
@@ -241,13 +241,13 @@
       </inertial>
       <!-- STEERING MOTOR -->
       <collision>
-        <origin xyz="${str_pos_x} ${str_pos_y-str_y/2} ${str_pos_z}" rpy="0 0 0"/>
+        <origin xyz="${str_pos_x} ${str_pos_y-str_y/2} ${str_pos_z * side_sign}" rpy="0 0 0"/>
         <geometry>
           <box size="${str_x} ${str_y} ${str_z}"/>
         </geometry>
       </collision>
       <visual>
-        <origin xyz="${str_pos_x} ${str_pos_y-str_y/2} ${str_pos_z}" rpy="0 0 0"/>
+        <origin xyz="${str_pos_x} ${str_pos_y-str_y/2} ${str_pos_z * side_sign}" rpy="0 0 0"/>
         <geometry>
           <box size="${str_x} ${str_y} ${str_z}"/>
         </geometry>
@@ -277,27 +277,28 @@
               ixz="0"
               iyz="0"/>
       </inertial>
+
       <!-- WHEEL BRACKET -->
       <collision>
-        <origin xyz="0.0 0.049 -0.0545" rpy="0 0 0"/>
+        <origin xyz="0.0 ${0.049 * side_sign} -0.0545" rpy="0 0 0"/>
         <geometry>
           <box size="0.044 0.006 0.109"/>
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0.0 0.049 -0.0545" rpy="0 0 0"/>
+        <origin xyz="0.0 ${0.049 * side_sign} -0.0545" rpy="0 0 0"/>
         <geometry>
           <box size="0.044 0.006 0.109"/>
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.013 -0.00325" rpy="0 0 0"/>
+        <origin xyz="0.0 ${0.013 * side_sign} -0.00325" rpy="0 0 0"/>
         <geometry>
           <box size="0.044 0.078 0.0065"/>
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0.0 0.013 -0.00325" rpy="0 0 0"/>
+        <origin xyz="0.0 ${0.013 * side_sign} -0.00325" rpy="0 0 0"/>
         <geometry>
           <box size="0.044 0.078 0.0065"/>
         </geometry>
@@ -310,7 +311,7 @@
       <child link="link_DRV_${position}"/>
       <limit effort="${limit_drive_effort}" velocity="${limit_drive_velocity}"/>
       <origin xyz="${wheel_x} ${wheel_y} ${wheel_z}" rpy="-1.57 0 0"/>
-      <axis xyz="0 0 ${driving_direction}"/>
+      <axis xyz="0 0 1"/>
       <dynamics damping="${damping}" friction="${friction}"/>
     </joint>
 
@@ -379,15 +380,14 @@
   
   <xacro:bogie position="${side_bogie_left_name}" bogie_mass="${side_bogie_mass}" bogie_r="${side_bogie_r}" bogie_l="${side_bogie_l}" dep_pos_z="${side_dep_pos_z-dep_z/2}" dep_rot_y="${0.0}">
     <origin xyz="${side_bogie_pos_x} ${side_bogie_pos_y} ${side_bogie_pos_z}" rpy="${- pi / 2} 0 0"/>
-    <cylinder length="${side_bogie_l}" radius="${side_bogie_r}"/>
   </xacro:bogie>
 
-  <xacro:wheel_assembly position="LF" bogie_name="${side_bogie_left_name}" driving_direction="1" str_pos_x="${str_pos_short_x-str_x_link_diff}">
+  <xacro:wheel_assembly position="LF" bogie_name="${side_bogie_left_name}" str_pos_x="${str_pos_short_x-str_x_link_diff}" side_sign="1">
     <origin xyz="${side_dep_pos_front_x} ${side_dep_pos_y} ${side_dep_pos_z}" rpy="0 0 0"/>
     <origin xyz="${str_pos_short_x} ${str_pos_y} ${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
 
-  <xacro:wheel_assembly position="LM" bogie_name="${side_bogie_left_name}" driving_direction="1" str_pos_x="${-(str_pos_long_x-str_x_link_diff)}">
+  <xacro:wheel_assembly position="LM" bogie_name="${side_bogie_left_name}" str_pos_x="${-(str_pos_long_x-str_x_link_diff)}" side_sign="1">
     <origin xyz="-${side_dep_pos_mid_x} ${side_dep_pos_y} ${side_dep_pos_z}" rpy="0 0 0"/>
     <origin xyz="-${str_pos_long_x} ${str_pos_y} ${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
@@ -396,37 +396,35 @@
   <!-- RIGHT BOGIE  -->
   <xacro:property name="side_bogie_right_name" value="RFB" />
 
-  <xacro:bogie position="${side_bogie_right_name}" bogie_mass="${side_bogie_mass}" bogie_r="${side_bogie_r}" bogie_l="${side_bogie_l}" dep_pos_z="${side_dep_pos_z-dep_z/2}" dep_rot_y="${0.0}">
-    <origin xyz="${side_bogie_pos_x} -${side_bogie_pos_y} ${side_bogie_pos_z}" rpy="${- pi / 2} 0 ${pi}"/>
-    <cylinder length="${side_bogie_l}" radius="${side_bogie_r}"/>
+  <xacro:bogie position="${side_bogie_right_name}" bogie_mass="${side_bogie_mass}" bogie_r="${side_bogie_r}" bogie_l="${side_bogie_l}" dep_pos_z="-${side_dep_pos_z-dep_z/2}" dep_rot_y="${0.0}">
+    <origin xyz="${side_bogie_pos_x} -${side_bogie_pos_y} ${side_bogie_pos_z}" rpy="${- pi / 2} 0 0"/>
   </xacro:bogie>
 
-  <xacro:wheel_assembly position="RF" bogie_name="${side_bogie_right_name}" driving_direction="-1" str_pos_x="${-(str_pos_short_x-str_x_link_diff)}">
-    <origin xyz="-${side_dep_pos_front_x} ${side_dep_pos_y} ${side_dep_pos_z}" rpy="0 0 0"/>
-    <origin xyz="-${str_pos_short_x} ${str_pos_y} ${str_pos_z}" rpy="${pi / 2} 0 0"/>
+  <xacro:wheel_assembly position="RF" bogie_name="${side_bogie_right_name}" str_pos_x="${str_pos_short_x-str_x_link_diff}" side_sign="-1">
+    <origin xyz="${side_dep_pos_front_x} ${side_dep_pos_y} -${side_dep_pos_z}" rpy="0 0 0"/>
+    <origin xyz="${str_pos_short_x} ${str_pos_y} -${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
 
-  <xacro:wheel_assembly position="RM" bogie_name="${side_bogie_right_name}" driving_direction="-1" str_pos_x="${(str_pos_long_x-str_x_link_diff)}">
-    <origin xyz="${side_dep_pos_mid_x} ${side_dep_pos_y} ${side_dep_pos_z}" rpy="0 0 0"/>
-    <origin xyz="${str_pos_long_x} ${str_pos_y} ${str_pos_z}" rpy="${pi / 2} 0 0"/>
+  <xacro:wheel_assembly position="RM" bogie_name="${side_bogie_right_name}" str_pos_x="${-(str_pos_long_x-str_x_link_diff)}" side_sign="-1">
+    <origin xyz="-${side_dep_pos_mid_x} ${side_dep_pos_y} -${side_dep_pos_z}" rpy="0 0 0"/>
+    <origin xyz="-${str_pos_long_x} ${str_pos_y} -${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
 
   <!-- REAR BOGIE  -->
   <xacro:property name="bogie_rear_name" value="MRB" />
 
-  <xacro:bogie position="${bogie_rear_name}" bogie_mass="${rear_bogie_mass}" bogie_r="${rear_bogie_r}" bogie_l="${rear_bogie_l}" dep_pos_z="${rear_dep_pos_z}" dep_rot_y="${-pi/2}">
-    <origin xyz="${rear_bogie_pos_x} ${rear_bogie_pos_y} ${rear_bogie_pos_z}" rpy="${- pi / 2} 0 ${pi / 2}"/>
-    <cylinder length="${rear_bogie_l}" radius="${rear_bogie_r}"/>
+  <xacro:bogie position="${bogie_rear_name}" bogie_mass="${rear_bogie_mass}" bogie_r="${rear_bogie_r}" bogie_l="${rear_bogie_l}" dep_pos_z="-${rear_dep_pos_z}" dep_rot_y="${-pi/2}">
+    <origin xyz="${rear_bogie_pos_x} ${rear_bogie_pos_y} ${rear_bogie_pos_z}" rpy="${- pi / 2} 0 ${- pi / 2}"/>
   </xacro:bogie>
 
-  <xacro:wheel_assembly position="LR" bogie_name="${bogie_rear_name}" driving_direction="1" str_pos_x="${-(str_pos_short_x-str_x_link_diff)}">
-    <origin xyz="${rear_dep_pos_x} ${rear_dep_pos_y} ${rear_dep_pos_z}" rpy="0 ${pi / 2} 0"/>
+  <xacro:wheel_assembly position="LR" bogie_name="${bogie_rear_name}" str_pos_x="${-(str_pos_short_x-str_x_link_diff)}" side_sign="1">
+    <origin xyz="-${rear_dep_pos_x} ${rear_dep_pos_y} -${rear_dep_pos_z}" rpy="0 ${- pi / 2} 0"/>
     <origin xyz="-${str_pos_short_x} ${str_pos_y} ${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
 
-  <xacro:wheel_assembly position="RR" bogie_name="${bogie_rear_name}" driving_direction="-1" str_pos_x="${(str_pos_short_x-str_x_link_diff)}">
-    <origin xyz="-${rear_dep_pos_x} ${rear_dep_pos_y} ${rear_dep_pos_z}" rpy="0 ${3 * pi / 2} 0"/>
-    <origin xyz="${str_pos_short_x} ${str_pos_y} ${str_pos_z}" rpy="${pi / 2} 0 0"/>
+  <xacro:wheel_assembly position="RR" bogie_name="${bogie_rear_name}" str_pos_x="${-(str_pos_short_x-str_x_link_diff)}" side_sign="-1">
+    <origin xyz="${rear_dep_pos_x} ${rear_dep_pos_y} -${rear_dep_pos_z}" rpy="0 ${- pi / 2} 0"/>
+    <origin xyz="-${str_pos_short_x} ${str_pos_y} -${str_pos_z}" rpy="${pi / 2} 0 0"/>
   </xacro:wheel_assembly>
 
 

--- a/urdf/marta.xacro
+++ b/urdf/marta.xacro
@@ -307,7 +307,7 @@
       <parent link="link_STR_${position}"/>
       <child link="link_DRV_${position}"/>
       <limit effort="${limit_drive_effort}" velocity="${limit_drive_velocity}"/>
-      <origin xyz="${wheel_x} ${wheel_y} ${wheel_z}" rpy="-1.57 0 0"/>
+      <origin xyz="${wheel_x} ${wheel_y * side_sign} ${wheel_z}" rpy="${-pi/2} 0 0"/>
       <axis xyz="0 0 1"/>
       <dynamics damping="${damping}" friction="${friction}"/>
     </joint>

--- a/urdf/marta.xacro
+++ b/urdf/marta.xacro
@@ -211,6 +211,7 @@
   </xacro:macro>
 
   <!-- Definition for a wheel assembly -->
+  <!-- side_sign inverts some geometry values and needs to be 1 for left side assemblies and -1 for right side assemblies -->
   <xacro:macro name="wheel_assembly" params="position bogie_name str_pos_x side_sign *origin_DEP *origin_STR">
 
     <!-- DEPLOYMENT JOINT -->
@@ -370,7 +371,7 @@
     </transmission>
   </xacro:macro>
 
-  <!-- Define all the wheel assemblies as set their positions -->
+  <!-- Define all wheel assemblies and set their positions -->
   <!-- LEFT BOGIE  -->
   <xacro:property name="side_bogie_left_name" value="LFB" />
   


### PR DESCRIPTION
I had a look at the URDF and made some small changes to bring the coordinate frames of the bogies, DEP, STR and DRV joints in line with the lab convention where the rotation axes are pointing in the same direction as the axes of the body coordinate frame. This also makes the `driving_direction` parameter obsolete. I also moved the cylinder element into the bogie block since the `bogie_l` and `bogie_r` parameters are passed into there anyway.