### PR TITLE
Fix launch argument 'default_bt_xml_filename'

### DIFF
--- a/config/nav2_params.yaml
+++ b/config/nav2_params.yaml
@@ -49,7 +49,7 @@ amcl_rclcpp_node:
 bt_navigator:
   ros__parameters:
     use_sim_time: True
-    bt_xml_filename: "navigate_w_replanning.xml"
+    default_bt_xml_filename: "navigate_w_replanning_distance.xml"
     plugin_lib_names:
     - nav2_compute_path_to_pose_action_bt_node
     - nav2_follow_path_action_bt_node
@@ -59,13 +59,20 @@ bt_navigator:
     - nav2_clear_costmap_service_bt_node
     - nav2_is_stuck_condition_bt_node
     - nav2_goal_reached_condition_bt_node
+    - nav2_goal_updated_condition_bt_node
     - nav2_initial_pose_received_condition_bt_node
     - nav2_reinitialize_global_localization_service_bt_node
     - nav2_rate_controller_bt_node
+    - nav2_distance_controller_bt_node
+    - nav2_speed_controller_bt_node
+    - nav2_truncate_path_action_bt_node
+    - nav2_goal_updater_node_bt_node
     - nav2_recovery_node_bt_node
     - nav2_pipeline_sequence_bt_node
     - nav2_round_robin_node_bt_node
     - nav2_transform_available_condition_bt_node
+    - nav2_time_expired_condition_bt_node
+    - nav2_distance_traveled_condition_bt_node
 
 bt_navigator_rclcpp_node:
   ros__parameters:


### PR DESCRIPTION
- Path is now being created but marta is not moving when running
navigation_simulation.launch.py

- To make rover move there is the need to provide a locomotion mode to marta rover, otherwise it would be waiting for it to be set indefinitely. This can be done either by using the gamepad or gamepad emulation, running the following command:  `ros2 run gamepad_emulation gamepad_emulation_node --ros-args -r joy:=gamepad `

- Once the emulation launches hold `1`  to select the locomotion mode. You will see in the navigation_simulation.launch.py terminal that the locomotion mode has changed from stop_mode to simple_rover_locomotion_mode. 

- You can now set a path using Navigation2Goal.
- Further work will be done to automatically set the locomotion mode on startup.