### PR TITLE
Update gazebo/rviz config for stereocam support

### DIFF
--- a/rviz/gamepad_sim.rviz
+++ b/rviz/gamepad_sim.rviz
@@ -371,6 +371,34 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 100
+        Min Value: -100
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8 
+      Decay Time: 0
+      Enabled: true
+      Name: StereoPointcloud
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /loc_cam/pointcloud
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
     - Class: rviz_default_plugins/Image
       Enabled: true
       Max Value: 1
@@ -382,9 +410,9 @@ Visualization Manager:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
-        Reliability Policy: Reliable
+        Reliability Policy: Best Effort
         Value: /nav_cam/left/image_raw
-      Value: true
+      Value: false
     - Class: rviz_default_plugins/Image
       Enabled: true
       Max Value: 1
@@ -396,9 +424,9 @@ Visualization Manager:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
-        Reliability Policy: Reliable
+        Reliability Policy: Best Effort
         Value: /loc_cam/left/image_raw
-      Value: true
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/urdf/bb2.gazebo
+++ b/urdf/bb2.gazebo
@@ -5,13 +5,12 @@
       <!-- Specs from https://www.upc.edu/sct/ca/documents_equipament/d_186_id-488.pdf -->
       <xacro:property name="baseline" value="0.12" />
 
-      <xacro:macro name="bb2_sensor" params="camera_name sensor_name pos_y">
-        <sensor type="camera" name="${camera_name}/${sensor_name}">
+      <xacro:macro name="bb2_sensor" params="camera_name pos_y">
+        <sensor type="multicamera" name="${camera_name}">
           <update_rate>20.0</update_rate>
           <visualize>false</visualize>
-
-          <camera>
-            <pose>0.0 ${pos_y} 0.0 0 0 0</pose>
+          <camera name="left">
+            <pose>0.0 ${+pos_y} 0.0 0 0 0</pose>
             <horizontal_fov>${97 * pi/180.0}</horizontal_fov>
             <image>
               <format>R8G8B8</format>
@@ -22,28 +21,44 @@
               <near>0.01</near>
               <far>100</far>
             </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <camera name="right">
+            <pose>0 ${-pos_y} 0.0 0 0 0</pose>
+            <horizontal_fov>${97 * pi/180.0}</horizontal_fov>
+            <image>
+              <format>R8G8B8</format>
+              <width>1024</width>
+              <height>768</height>
+            </image>
+            <clip>
+              <near>0.01</near>
+              <far>100</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.007</stddev>
+            </noise>
           </camera>
 
-          <plugin name="camera_camera_controller" filename="libgazebo_ros_camera.so">
-            <alwaysOn>true</alwaysOn>
-            <updateRate>20.0</updateRate>
-            <cameraName>${camera_name}</cameraName>
-            <imageTopicName>image_raw</imageTopicName>
-            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-            <frameName>link_${camera_name}</frameName>
-            <hackBaseline>${2*pos_y}</hackBaseline>
-            <distortionK1>0.0</distortionK1>
-            <distortionK2>0.0</distortionK2>
-            <distortionK3>0.0</distortionK3>
-            <distortionT1>0.0</distortionT1>
-            <distortionT2>0.0</distortionT2>
+          <plugin name="${camera_name}_camera_controller" filename="libgazebo_ros_camera.so">
+            <always_on>true</always_on>
+            <update_rate>20.0</update_rate>
+            <camera_name>${camera_name}</camera_name>
+            <image_topic_name>image_raw</image_topic_name>
+            <camera_info_topic_name>camera_info</camera_info_topic_name>
+            <frame_name>link_${camera_name}_frame</frame_name>
+            <hack_baseline>${2*pos_y}</hack_baseline>
           </plugin>
         </sensor>
       </xacro:macro>
 
-      <xacro:bb2_sensor camera_name="${cam_name}" sensor_name="left" pos_y="${baseline/2}"/>
-
-      <xacro:bb2_sensor camera_name="${cam_name}" sensor_name="right" pos_y="${-baseline/2}"/>
+      <xacro:bb2_sensor camera_name="${cam_name}" pos_y="${baseline/2}" />
 
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>

--- a/urdf/bb2.xacro
+++ b/urdf/bb2.xacro
@@ -20,7 +20,6 @@
         <parent link="${parent_link}"/>
         <child link="link_${name}"/>
         <xacro:insert_block name="origin_cam" />
-        <axis xyz="1 0 0" />
     </joint>
 
     <!-- CAMERA LINK -->
@@ -50,6 +49,14 @@
       </visual>
     </link>
 
+    <!-- By convention the image frames axes are defines as: x-right, y-down, z-out of image  -->
+    <!-- That's why a another link for the image frame is needed. -->
+    <joint name="joint_${name}_frame" type="fixed">
+      <origin xyz="0.0 0.0 0.0" rpy="${-pi/2} 0 ${-pi/2}"/>
+      <parent link="link_${name}"/>
+      <child link="link_${name}_frame"/>
+    </joint>
+    <link name="link_${name}_frame"/>
 
   </xacro:macro>
 </robot>


### PR DESCRIPTION
- Use multicam feature of gazebo camera plugin
- Define camera_frame link to follow image
  frame convention
- Set image topic in rviz to "Best Effort"
- Add stereo point cloud to rviz

related to [PR14](https://github.com/esa-prl/marta_launch/pull/14) in marta_launch.